### PR TITLE
Render shared user chat heads

### DIFF
--- a/client/src/components/navbar.jsx
+++ b/client/src/components/navbar.jsx
@@ -12,7 +12,7 @@ export default class NavBar extends React.Component {
     // this is probably going to have asynchronous issues => refactor to cbs or promises
     var sharedUsers = this.props.getSharedUsers(docId, userId);
     console.log('shared users have been had:', sharedUsers);
-    // this.props.setSharedUsersState(sharedUsers);
+    this.props.setSharedUsersState(sharedUsers);
   }
 
   render() {

--- a/client/src/components/navbar.jsx
+++ b/client/src/components/navbar.jsx
@@ -6,13 +6,13 @@ export default class NavBar extends React.Component {
     super(props);
   };
 
+// Probably, the logic for getting shared users should be an effect of textEditor mounting
   componentWillMount() {
+    console.log('inside NavBar componentWillMount');
     var docId = this.props.curDoc;
     var userId = this.props.curUser;
-    // this is probably going to have asynchronous issues => refactor to cbs or promises
-    var sharedUsers = this.props.getSharedUsers(docId, userId);
-    console.log('shared users have been had:', sharedUsers);
-    this.props.setSharedUsersState(sharedUsers);
+    this.props.getSharedUsers(docId, userId);
+    // this.props.setSharedUsersState(sharedUsers);
   }
 
   render() {

--- a/client/src/components/navbar.jsx
+++ b/client/src/components/navbar.jsx
@@ -2,15 +2,15 @@ import React from 'react';
 
 // Later: on componentDidMount: get shared users and render circles
 
-const NavBar = () => 
+const NavBar = (props) => 
   (
     <div className="NavBarWrapper">
       <div className="NavBarContainer">
         <div className="userCircles">
-          <div className="userCircle"></div>
-          <div className="userCircle"></div>
-          <div className="userCircle"></div>
-          <div className="userCircle"></div>
+        {props.curSharedUsers.map((user, i) => {
+          var initials = props.getInitials(user); 
+          return <div key={i} className='userCircle'>{initials}</div>
+        })}
         </div>
         <div className="nav-bar-buttons">
           <img id="call-nav-button" src="public/images/makecall.png"></img>
@@ -21,3 +21,9 @@ const NavBar = () =>
     </div>
   );
 export default NavBar;
+
+
+          // <div className="userCircle"></div>
+          // <div className="userCircle"></div>
+          // <div className="userCircle"></div>
+          // <div className="userCircle"></div>

--- a/client/src/components/navbar.jsx
+++ b/client/src/components/navbar.jsx
@@ -1,29 +1,60 @@
 import React from 'react';
 
-// Later: on componentDidMount: get shared users and render circles
+// STATEFUL B/C ADDING COMPONENTWILLMOUNT
+export default class NavBar extends React.Component {
+  constructor(props) {
+    super(props);
+  };
 
-const NavBar = (props) => 
-  (
-    <div className="NavBarWrapper">
-      <div className="NavBarContainer">
-        <div className="userCircles">
-        {props.curSharedUsers.map((user, i) => {
-          var initials = props.getInitials(user); 
-          return <div key={i} className='userCircle'>{initials}</div>
-        })}
-        </div>
-        <div className="nav-bar-buttons">
-          <img id="call-nav-button" src="public/images/makecall.png"></img>
-          <button>Share</button>
-          <a href="http://localhost:8000/">logout</a>
+  componentWillMount() {
+    var docId = this.props.curDoc;
+    var userId = this.props.curUser;
+    // this is probably going to have asynchronous issues => refactor to cbs or promises
+    var sharedUsers = this.props.getSharedUsers(docId, userId);
+    console.log('shared users have been had:', sharedUsers);
+    // this.props.setSharedUsersState(sharedUsers);
+  }
+
+  render() {
+    return (
+      <div className="NavBarWrapper">
+        <div className="NavBarContainer">
+          <div className="userCircles">
+          {this.props.curSharedUsers.map((user, i) => {
+            var initials = this.props.getInitials(user); 
+            return <div key={i} className='userCircle'>{initials}</div>
+          })}
+          </div>
+          <div className="nav-bar-buttons">
+            <img id="call-nav-button" src="public/images/makecall.png"></img>
+            <button>Share</button>
+            <a href="http://localhost:8000/">logout</a>
+          </div>
         </div>
       </div>
-    </div>
-  );
-export default NavBar;
+    );
+  }
+};
 
 
-          // <div className="userCircle"></div>
-          // <div className="userCircle"></div>
-          // <div className="userCircle"></div>
-          // <div className="userCircle"></div>
+// STATELESS VERSION
+// const NavBar = (props) => 
+//   (
+//     <div className="NavBarWrapper">
+//       <div className="NavBarContainer">
+//         <div className="userCircles">
+//         {props.curSharedUsers.map((user, i) => {
+//           var initials = props.getInitials(user); 
+//           return <div key={i} className='userCircle'>{initials}</div>
+//         })}
+//         </div>
+//         <div className="nav-bar-buttons">
+//           <img id="call-nav-button" src="public/images/makecall.png"></img>
+//           <button>Share</button>
+//           <a href="http://localhost:8000/">logout</a>
+//         </div>
+//       </div>
+//     </div>
+//   );
+// export default NavBar;
+

--- a/client/src/components/textVideoPage.jsx
+++ b/client/src/components/textVideoPage.jsx
@@ -33,13 +33,31 @@ export default class TextVideoPage extends React.Component {
       curDoc: 2,
       curSharedUsers: dummyUsers
     };
+
+    this.getInitials = this.getInitials.bind(this);
   };
+
+  getInitials (user) {
+    if (user.firstname !== null) {
+      var firstInit = user.firstname[0];
+    } else {
+      var firstInit = '';
+    }
+
+    if (user.lastname !== null) {
+      var lastInit = user.lastname[0];
+    } else {
+      var lastInit = '';
+    }
+
+    return firstInit + lastInit;
+  }
 
   render() {
     return (
       <div>
         <div className="NavBar">
-          <NavBar curDoc={this.state.curDoc} curSharedUsers={this.state.curSharedUsers} />
+          <NavBar curDoc={this.state.curDoc} curSharedUsers={this.state.curSharedUsers} getInitials={this.getInitials} />
         </div>
         <div id="editor">
           <p>Type here...</p>
@@ -52,6 +70,7 @@ export default class TextVideoPage extends React.Component {
     );
   }
 }
+
 
 
 // /* COMPONENT WITH CHAT */

--- a/client/src/components/textVideoPage.jsx
+++ b/client/src/components/textVideoPage.jsx
@@ -6,23 +6,53 @@ import Chat from './chat.jsx';
 import NavBar from './navbar.jsx';
 
 // /* COMPONENT WITHOUT CHAT */
+var dummyUsers = [  {
+    "id": 2,
+    "firstname": "Corwin",
+    "lastname": "Crownover###",
+    "email": "crwozzzzz@gmail.com"
+  },
+  {
+    "id": 6,
+    "firstname": null,
+    "lastname": null,
+    "email": null
+  },
+  {
+    "id": 7,
+    "firstname": "Brandon",
+    "lastname": "Tiqui",
+    "email": "btiqui@gmail.com"
+  }]
+
 export default class TextVideoPage extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      curDoc: 2,
+      curSharedUsers: dummyUsers
+    };
+  };
+
   render() {
     return (
       <div>
         <div className="NavBar">
-          <NavBar />
+          <NavBar curDoc={this.state.curDoc} curSharedUsers={this.state.curSharedUsers} />
         </div>
         <div id="editor">
           <p>Type here...</p>
         </div>
-        <div className="video-and-chat">
-          <AppVideo className="Video"/>
+        <div className="Video">
+          <AppVideo />
+          <Chat />
         </div>
       </div>
     );
   }
 }
+
 
 // /* COMPONENT WITH CHAT */
 // export default class TextVideoPage extends React.Component {

--- a/client/src/components/textVideoPage.jsx
+++ b/client/src/components/textVideoPage.jsx
@@ -30,12 +30,28 @@ export default class TextVideoPage extends React.Component {
     super(props);
 
     this.state = {
+      curUser: 2,
       curDoc: 2,
       curSharedUsers: dummyUsers
     };
 
+    this.getSharedUsers = this.getSharedUsers.bind(this);
     this.getInitials = this.getInitials.bind(this);
+    this.setSharedUsersState = this.setSharedUsersState.bind(this);
   };
+
+  getSharedUsers (docId, userId) {
+    // send request to server
+    console.log('inside FE getSharedUsers');
+    return [
+      {
+        "id": 111,
+        "firstname": "HEYITWORKS",
+        "lastname": "BAM",
+        "email": "yooooo@gmail.com"
+      }
+    ];
+  }
 
   getInitials (user) {
     if (user.firstname !== null) {
@@ -53,11 +69,22 @@ export default class TextVideoPage extends React.Component {
     return firstInit + lastInit;
   }
 
+  setSharedUsersState(users) {
+    this.setState({curSharedUsers: users});
+    console.log('current shared users:', this.state.curSharedUsers);
+  }
+
   render() {
     return (
       <div>
         <div className="NavBar">
-          <NavBar curDoc={this.state.curDoc} curSharedUsers={this.state.curSharedUsers} getInitials={this.getInitials} />
+          <NavBar 
+            curDoc={this.state.curDoc} 
+            curUser={this.state.curUser}
+            curSharedUsers={this.state.curSharedUsers} 
+            getSharedUsers={this.getSharedUsers}
+            getInitials={this.getInitials}
+            setSharedUsersState={this.setSharedUsersState} />
         </div>
         <div id="editor">
           <p>Type here...</p>

--- a/client/src/components/textVideoPage.jsx
+++ b/client/src/components/textVideoPage.jsx
@@ -6,51 +6,40 @@ import Chat from './chat.jsx';
 import NavBar from './navbar.jsx';
 
 // /* COMPONENT WITHOUT CHAT */
-var dummyUsers = [  {
-    "id": 2,
-    "firstname": "Corwin",
-    "lastname": "Crownover###",
-    "email": "crwozzzzz@gmail.com"
-  },
-  {
-    "id": 6,
-    "firstname": null,
-    "lastname": null,
-    "email": null
-  },
-  {
-    "id": 7,
-    "firstname": "Brandon",
-    "lastname": "Tiqui",
-    "email": "btiqui@gmail.com"
-  }]
-
 export default class TextVideoPage extends React.Component {
   constructor(props) {
     super(props);
 
     this.state = {
-      curUser: 2,
+      curUser: 18,
       curDoc: 2,
-      curSharedUsers: dummyUsers
+      curSharedUsers: []
     };
 
     this.getSharedUsers = this.getSharedUsers.bind(this);
     this.getInitials = this.getInitials.bind(this);
-    this.setSharedUsersState = this.setSharedUsersState.bind(this);
   };
 
   getSharedUsers (docId, userId) {
     // send request to server
     console.log('inside FE getSharedUsers');
-    return [
-      {
-        "id": 111,
-        "firstname": "HEYITWORKS",
-        "lastname": "BAM",
-        "email": "yooooo@gmail.com"
+    $.ajax({
+      method: 'GET',
+      url: '/userdocs',
+      dataType: 'json',
+      data: {
+        docId: docId,
+        userId: userId
+      },
+      success: (data) => {
+        console.log('getSharedUsers success:', data);
+        this.setState({curSharedUsers: data});
+        console.log('state sharedusers:', this.state.curSharedUsers);
+      },
+      error: (err) => {
+        console.log('getSharedUsers error:', err);
       }
-    ];
+    })
   }
 
   getInitials (user) {
@@ -69,11 +58,6 @@ export default class TextVideoPage extends React.Component {
     return firstInit + lastInit;
   }
 
-  setSharedUsersState(users) {
-    this.setState({curSharedUsers: users});
-    console.log('current shared users:', this.state.curSharedUsers);
-  }
-
   render() {
     return (
       <div>
@@ -83,15 +67,13 @@ export default class TextVideoPage extends React.Component {
             curUser={this.state.curUser}
             curSharedUsers={this.state.curSharedUsers} 
             getSharedUsers={this.getSharedUsers}
-            getInitials={this.getInitials}
-            setSharedUsersState={this.setSharedUsersState} />
+            getInitials={this.getInitials} />
         </div>
         <div id="editor">
           <p>Type here...</p>
         </div>
         <div className="Video">
           <AppVideo />
-          <Chat />
         </div>
       </div>
     );

--- a/server/resources/controllers/userDocumentController.js
+++ b/server/resources/controllers/userDocumentController.js
@@ -23,16 +23,11 @@ exports.createUserDoc = function(req, res, next) {
 
 // USE CASE: on Text Component / NavBar Component load, get shared users
 // note: may want to modularize to be 1. getUserDocs, 2. Get sharedUsers
-// 1. get UserDoc entries
-// 2. Get userIds for each entry
-// 3. get userobject for each userId
-// 4. modify objects before sending back in the response
-
-// TODO: FE connection needs to pass in docId & current userId
-
 exports.getSharedUsers = function(req, res, next) {
   var docId = req.query.docId;
   var curUserId = req.query.userId;
+  console.log('inside controller getSharedUsers');
+  console.log('docId, curUserId:', docId, curUserId);
 
   // 1. Find all UserDoc entries
   UserDoc.findAll({where: {documentId: docId}})


### PR DESCRIPTION
Implemented getSharedUsers method on the client
- Retrieves shared users from DB given a docId (hardcoded) & current userId (hardcoded)

TODO
- Fix wonky css
- Fix bug: duplication of current user's chat head / userDoc entry in db
- Hook up current docId state, remove hardcoded docId
- Pass in the real current userId once auth is working, remove hardcoded userid
- Eventually refactor for redux
